### PR TITLE
Update GO installation instructions

### DIFF
--- a/run-a-node.md
+++ b/run-a-node.md
@@ -14,30 +14,41 @@ sudo apt update && sudo apt dist-upgrade -y
 sudo apt install build-essential git unzip curl wget
 ```
 
-### Install Golang
-
-1. Download `go` 1.18.x
-```
-wget https://go.dev/dl/go1.18.2.linux-amd64.tar.gz
-```
-2. Extract the runtime
-```
-sudo tar -C /usr/local -xzf go1.18.2.linux-amd64.tar.gz
-```
 
 ## Prepare testnet environment
 
-1. Create the `kuji` user and switch to it
+Create the `kuji` user and switch to it
 ```
 sudo useradd -m kuji
 sudo su -s /bin/bash -l kuji
 ```
-2. Add go to your path (add these lines to `~/.profile` or `~/.bashrc`)
+
+### Install Golang
+
+1. Download `go` 1.18.x
 ```
-export PATH=$PATH:/usr/local/go/bin
-export PATH=$PATH:$(go env GOPATH)/bin
+# remove old go version
+sudo rm -rvf /usr/local/go/
+
+# download recent go version
+wget https://golang.org/dl/go1.18.3.linux-amd64.tar.gz
+
+# install go
+sudo tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz
+
+# remove unneeded installer
+rm go1.18.3.linux-amd64.tar.gz
+
+# source go
+cat <<EOF >> ~/.profile
+export GOROOT=/usr/local/go
+export GOPATH=$HOME/go
+export GO111MODULE=on
+export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
+EOF
+source ~/.profile
+go version
 ```
-3. Run `source ~/.profile` and/or `source ~/.bashrc`
 
 ## Now we build!
 


### PR DESCRIPTION
If someone already has `go` installed, then follows the previous instructions, they get the following error:

```
go install -tags "netgo ledger" -ldflags '-X github.com/cosmos/cosmos-sdk/version.Name=kujira -X github.com/cosmos/cosmos-sdk/version.ServerName=kujirad -X github.com/cosmos/cosmos-sdk/version.Version=0.4.0 -X github.com/cosmos/cosmos-sdk/version.Commit=98ff2a53c42c860c6c77f9999de4ab65e6e19248 -X "github.com/cosmos/cosmos-sdk/version.BuildTags=netgo ledger,"' ./cmd/kujirad
# runtime/internal/sys
/usr/local/go/src/runtime/internal/sys/consts.go:13:7: StackGuardMultiplier redeclared in this block
        /usr/local/go/src/runtime/internal/sys/arch.go:27:7: other declaration of StackGuardMultiplier
/usr/local/go/src/runtime/internal/sys/consts.go:16:7: DefaultPhysPageSize redeclared in this block
        /usr/local/go/src/runtime/internal/sys/arch.go:36:7: other declaration of DefaultPhysPageSize
/usr/local/go/src/runtime/internal/sys/consts.go:20:7: PCQuantum redeclared in this block
        /usr/local/go/src/runtime/internal/sys/arch.go:40:7: other declaration of PCQuantum
/usr/local/go/src/runtime/internal/sys/consts.go:23:7: Int64Align redeclared in this block
        /usr/local/go/src/runtime/internal/sys/arch.go:43:7: other declaration of Int64Align
/usr/local/go/src/runtime/internal/sys/consts.go:30:7: MinFrameSize redeclared in this block
        /usr/local/go/src/runtime/internal/sys/arch.go:50:7: other declaration of MinFrameSize
/usr/local/go/src/runtime/internal/sys/consts.go:34:7: StackAlign redeclared in this block
        /usr/local/go/src/runtime/internal/sys/arch.go:54:7: other declaration of StackAlign
make: *** [Makefile:64: install] Error 2
```

This makes it so step 1 is "removal" of the previous go installation. If they didn't have go installed, it does nothing.