### PR TITLE
Update oracle-price-feeder.md to correct link

### DIFF
--- a/validators/run-a-node/oracle-price-feeder.md
+++ b/validators/run-a-node/oracle-price-feeder.md
@@ -5,7 +5,7 @@ As a validator in the active set, you will be required to use the Oracle Price F
 ## Installation
 
 ```bash
-git clone git@github.com:Team-Kujira/oracle-price-feeder.git
+git clone https://github.com/Team-Kujira/oracle-price-feeder.git
 cd oracle-price-feeder
 make install
 ```


### PR DESCRIPTION
The previous path only works if their ssh key is added to the organization.