### PR TITLE
Update slashing.md

### DIFF
--- a/governance/staking/slashing.md
+++ b/governance/staking/slashing.md
@@ -8,7 +8,7 @@ Slashing occurs under each of the following circumstances:&#x20;
 
 **Double Signing**: A validator signs two different blocks with the same chain ID at the same height
 
-Make sure validators you delegate to are protected against Double Signing. This suffers the most severe slashing penalty of 0.05% of the validator's and each delegator's staked positions.&#x20;
+Make sure validators you delegate to are protected against Double Signing. This suffers the most severe slashing penalty of 5% of the validator's and each delegator's staked positions.&#x20;
 
 **Downtime**: A Validator cannot be reached and is unresponsive for a period of time.&#x20;
 


### PR DESCRIPTION
According to https://raw.githubusercontent.com/Team-Kujira/networks/master/mainnet/kaiyo-1.json

 "slash_fraction_double_sign": "0.050000000000000000", i.e. 5%

"slashing": {
      "params": {
        "signed_blocks_window": "35000",
        "min_signed_per_window": "0.050000000000000000",
        "downtime_jail_duration": "600s",
        "slash_fraction_double_sign": "0.050000000000000000",
        "slash_fraction_downtime": "0.000100000000000000"