### PR TITLE
Fix: Github.com URL typo in FIN Docs

### DIFF
--- a/developers/dapp-front-ends/fin.md
+++ b/developers/dapp-front-ends/fin.md
@@ -4,7 +4,7 @@ description: Wield the first 100% decentralised order book exchange on Cosmos.
 
 # 📊 FIN
 
-For a demo trading bot on Fin, check out [https://github.com/TeamKujira/fin-bot-demo](https://github.com/TeamKujira/fin-bot-demo).
+For a demo trading bot on Fin, check out [https://github.com/TeamKujira/fin-bot-demo](https://github.com/Team-Kujira/fin-bot-demo).
 
 
 


### PR DESCRIPTION
fixed the Gitlab.com url